### PR TITLE
Support compdb for windows

### DIFF
--- a/aspects.bzl
+++ b/aspects.bzl
@@ -35,6 +35,12 @@ load("@rules_cuda//cuda/private:action_names.bzl", CUDA_COMPILE_ACTION_NAME = "C
 load("@rules_cuda//cuda/private:cuda_helper.bzl", "cuda_helper")
 load("@com_grail_bazel_config_compdb//:config.bzl", "cuda_enable")
 
+if cuda_enable:
+    load("@rules_cuda//cuda:deps.bzl", "register_detected_cuda_toolchains", "rules_cuda_deps")
+
+    rules_cuda_deps()
+    register_detected_cuda_toolchains()
+
 CompilationAspect = provider()
 
 _cpp_header_extensions = [

--- a/aspects.bzl
+++ b/aspects.bzl
@@ -30,7 +30,7 @@ load(
     "OBJCPP_COMPILE_ACTION_NAME",
     "OBJC_COMPILE_ACTION_NAME",
 )
-load("@com_grail_bazel_config_compdb//:config.bzl", "CUDA_COMPILE_ACTION_NAME", "cuda_enable", "cuda_helper", "find_cuda_toolchain")
+load("@com_grail_bazel_config_compdb//:config.bzl", "ACTION_NAMES", "ALLOW_CUDA_HDRS", "ALLOW_CUDA_SRCS", "BuildSettingInfo", "CudaArchsInfo", "CudaInfo", "config_helper", "cuda_enable", "cuda_helper", "find_cuda_toolchain", "paths", "unique", "use_cuda_toolchain")
 
 CompilationAspect = provider()
 
@@ -62,15 +62,6 @@ _objc_rules = [
     "objc_binary",
 ]
 
-_cuda_header_extension = [
-    "cuh",
-    "hpp",
-]
-
-_cuda_extension = [
-    "cu",
-] + _cuda_header_extension
-
 _cuda_rules = [
     "cuda_library",
 ]
@@ -89,9 +80,6 @@ def _is_cpp_target(srcs):
 
 def _is_objcpp_target(srcs):
     return any([src.extension == "mm" for src in srcs])
-
-def _is_cuda_target(srcs):
-    return any([src.extension in _cuda_extension for src in srcs])
 
 def _sources(ctx, target):
     srcs = []
@@ -286,49 +274,343 @@ def _objc_compile_commands(ctx, target, feature_configuration, cc_toolchain):
         ))
     return compile_commands
 
-def _cuda_compile_commands(ctx, target, feature_configuration, cuda_toolchain):
-    cuda_common = cuda_helper.create_common(ctx)
+def _check_src_extension(file, allowed_src_files):
+    for pattern in allowed_src_files:
+        if file.basename.endswith(pattern):
+            return True
+    return False
 
-    compiler = str(
-        cuda_helper.get_tool_for_action(
-            info = feature_configuration,
-            action_name = CUDA_COMPILE_ACTION_NAME,
-        ),
+def _check_srcs_extensions(ctx, allowed_src_files, rule_name):
+    for src in ctx.rule.attr.srcs:
+        files = src[DefaultInfo].files.to_list()
+        if len(files) == 1 and files[0].is_source:
+            if not _check_src_extension(files[0], allowed_src_files) and not files[0].is_directory:
+                fail("in srcs attribute of {} rule {}: source file '{}' is misplaced here".format(rule_name, ctx.label, str(src.label)))
+        else:
+            at_least_one_good = False
+            for file in files:
+                if _check_src_extension(file, allowed_src_files) or file.is_directory:
+                    at_least_one_good = True
+                    break
+            if not at_least_one_good:
+                fail("'{}' does not produce any {} srcs files".format(str(src.label), rule_name), attr = "srcs")
+
+def _resolve_workspace_root_includes(ctx):
+    src_path = paths.normalize(ctx.label.workspace_root)
+    bin_path = paths.normalize(paths.join(ctx.bin_dir.path, src_path))
+    return src_path, bin_path
+
+def _resolve_includes(ctx, path):
+    if paths.is_absolute(path):
+        fail("invalid absolute path", path)
+
+    src_path = paths.normalize(paths.join(ctx.label.workspace_root, ctx.label.package, path))
+    bin_path = paths.join(ctx.bin_dir.path, src_path)
+    return src_path, bin_path
+
+def _check_opts(opt):
+    opt = opt.strip()
+    if (opt.startswith("--generate-code") or opt.startswith("-gencode") or
+        opt.startswith("--gpu-architecture") or opt.startswith("-arch") or
+        opt.startswith("--gpu-code") or opt.startswith("-code") or
+        opt.startswith("--relocatable-device-code") or opt.startswith("-rdc") or
+        opt.startswith("--cuda") or opt.startswith("-cuda") or
+        opt.startswith("--preprocess") or opt.startswith("-E") or
+        opt.startswith("--compile") or opt.startswith("-c") or
+        opt.startswith("--cubin") or opt.startswith("-cubin") or
+        opt.startswith("--ptx") or opt.startswith("-ptx") or
+        opt.startswith("--fatbin") or opt.startswith("-fatbin") or
+        opt.startswith("--device-link") or opt.startswith("-dlink") or
+        opt.startswith("--lib") or opt.startswith("-lib") or
+        opt.startswith("--generate-dependencies") or opt.startswith("-M") or
+        opt.startswith("--generate-nonsystem-dependencies") or opt.startswith("-MM") or
+        opt.startswith("--run") or opt.startswith("-run")):
+        fail(opt, "is not allowed to be specified directly via copts")
+    return True
+
+def _get_cuda_archs_info(ctx):
+    return ctx.rule.attr._default_cuda_archs[CudaArchsInfo]
+
+def _create_common_info(
+        cuda_archs_info = None,
+        includes = [],
+        quote_includes = [],
+        system_includes = [],
+        headers = [],
+        transitive_headers = [],
+        defines = [],
+        local_defines = [],
+        compile_flags = [],
+        link_flags = [],
+        host_defines = [],
+        host_local_defines = [],
+        host_compile_flags = [],
+        host_link_flags = [],
+        ptxas_flags = [],
+        transitive_linking_contexts = []):
+    """Constructor of the common object.
+    Args:
+        cuda_archs_info: `CudaArchsInfo`.
+        includes: include paths. Can be used with `#include <...>` and `#include "..."`.
+        quote_includes: include paths. Can be used with `#include "..."`.
+        system_includes: include paths. Can be used with `#include <...>`.
+        headers: headers directly relate with this target.
+        transitive_headers: headers transitively gather from `deps`.
+        defines: public `#define`s. Pass to compiler driver directly. Will be seen by downstream targets.
+        local_defines: private `#define`s. Pass to compiler driver directly. Will not be seen by downstream targets.
+        compile_flags: flags pass to compiler driver directly.
+        link_flags: flags pass to device linker.
+        host_defines: public `#define`s. Pass to host compiler. Will be seen by downstream targets.
+        host_local_defines: private `#define`s. Pass to host compiler. Will not be seen by downstream targets.
+        host_compile_flags: flags pass to host compiler.
+        host_link_flags: flags pass to host linker.
+        ptxas_flags: flags pass to `ptxas`.
+        transitive_linking_contexts: `CcInfo.linking_context` extracted from `deps`
+    """
+    return struct(
+        cuda_archs_info = cuda_archs_info,
+        includes = includes,
+        quote_includes = quote_includes,
+        system_includes = system_includes,
+        headers = depset(headers, transitive = transitive_headers),
+        defines = defines,
+        local_defines = local_defines,
+        compile_flags = compile_flags,
+        link_flags = link_flags,
+        host_defines = host_defines,
+        host_local_defines = host_local_defines,
+        host_compile_flags = host_compile_flags,
+        host_link_flags = host_link_flags,
+        ptxas_flags = ptxas_flags,
+        transitive_linker_inputs = [ctx.linker_inputs for ctx in transitive_linking_contexts],
+        transitive_linking_contexts = transitive_linking_contexts,
     )
-    compile_flags = cuda_common.compile_flags
+
+def _create_common(ctx):
+    """Helper to gather and process various information from `ctx` object to ease the parameter passing for internal macros.
+
+    See `cuda_helper.create_common_info` what information a common object encapsulates.
+    """
+    attr = ctx.rule.attr
+
+    # gather include info
+    includes = []
+    system_includes = []
+    quote_includes = []
+    quote_includes.extend(_resolve_workspace_root_includes(ctx))
+    for inc in attr.includes:
+        system_includes.extend(_resolve_includes(ctx, inc))
+    for dep in attr.deps:
+        if CcInfo in dep:
+            includes.extend(dep[CcInfo].compilation_context.includes.to_list())
+            system_includes.extend(dep[CcInfo].compilation_context.system_includes.to_list())
+            quote_includes.extend(dep[CcInfo].compilation_context.quote_includes.to_list())
+
+    # gather header info
+    public_headers = []
+    private_headers = []
+    for fs in attr.hdrs:
+        public_headers.extend(fs.files.to_list())
+    for fs in attr.srcs:
+        hdr = [f for f in fs.files.to_list() if _check_src_extension(f, ALLOW_CUDA_HDRS)]
+        private_headers.extend(hdr)
+    headers = public_headers + private_headers
+    transitive_headers = []
+    for dep in attr.deps:
+        if CcInfo in dep:
+            transitive_headers.append(dep[CcInfo].compilation_context.headers)
+
+    # gather linker info
+    builtin_linking_contexts = []
+    if hasattr(attr, "_builtin_deps"):
+        builtin_linking_contexts = [dep[CcInfo].linking_context for dep in attr._builtin_deps if CcInfo in dep]
+
+    transitive_linking_contexts = [dep[CcInfo].linking_context for dep in attr.deps if CcInfo in dep]
+    transitive_linking_contexts.extend(builtin_linking_contexts)
+
+    # gather compile info
+    defines = []
+    local_defines = [i for i in attr.local_defines]
+    compile_flags = attr._default_host_copts[BuildSettingInfo].value + [o for o in attr.copts if _check_opts(o)]
+    link_flags = []
+    if hasattr(attr, "linkopts"):
+        link_flags.extend([o for o in attr.linkopts if _check_opts(o)])
+    host_defines = []
+    host_local_defines = [i for i in attr.host_local_defines]
+    host_compile_flags = [i for i in attr.host_copts]
+    host_link_flags = []
+    if hasattr(attr, "host_linkopts"):
+        host_link_flags.extend([i for i in attr.host_linkopts])
+    for dep in attr.deps:
+        if CudaInfo in dep:
+            defines.extend(dep[CudaInfo].defines.to_list())
+        if CcInfo in dep:
+            host_defines.extend(dep[CcInfo].compilation_context.defines.to_list())
+    defines.extend(attr.defines)
+    host_defines.extend(attr.host_defines)
+
+    ptxas_flags = [o for o in attr.ptxasopts if _check_opts(o)]
+
+    return _create_common_info(
+        cuda_archs_info = _get_cuda_archs_info(ctx),
+        includes = includes,
+        quote_includes = quote_includes,
+        system_includes = system_includes,
+        headers = headers,
+        transitive_headers = transitive_headers,
+        defines = defines,
+        local_defines = local_defines,
+        compile_flags = compile_flags,
+        link_flags = link_flags,
+        host_defines = host_defines,
+        host_local_defines = host_local_defines,
+        host_compile_flags = host_compile_flags,
+        host_link_flags = host_link_flags,
+        ptxas_flags = ptxas_flags,
+        transitive_linking_contexts = transitive_linking_contexts,
+    )
+
+def _get_all_unsupported_features(ctx, cuda_toolchain, unsupported_features):
+    all_unsupported = list(ctx.disabled_features)
+    all_unsupported.extend([f[1:] for f in ctx.rule.attr.features if f.startswith("-")])
+    if unsupported_features != None:
+        all_unsupported.extend(unsupported_features)
+    return unique(all_unsupported)
+
+def _get_all_requested_features(ctx, cuda_toolchain, requested_features):
+    all_features = []
+    compilation_mode = ctx.var.get("COMPILATION_MODE", None)
+    if compilation_mode == None:
+        print("unknown COMPILATION_MODE, use opt")
+        compilation_mode = "opt"
+    all_features.append(compilation_mode)
+
+    all_features.extend(ctx.features)
+    all_features.extend([f for f in ctx.rule.attr.features if not f.startswith("-")])
+    all_features.extend(requested_features)
+    all_features = unique(all_features)
+
+    # https://github.com/bazelbuild/bazel/blob/41feb616ae/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCommon.java#L953-L967
+    if "static_link_msvcrt" in all_features:
+        all_features.append("static_link_msvcrt_debug" if compilation_mode == "dbg" else "static_link_msvcrt_no_debug")
+    else:
+        all_features.append("dynamic_link_msvcrt_debug" if compilation_mode == "dbg" else "dynamic_link_msvcrt_no_debug")
+
+    return all_features
+
+def _configure_features(ctx, cuda_toolchain, requested_features = None, unsupported_features = None, _debug = False):
+    """Creates a feature_configuration instance.
+
+    Args:
+        ctx: The rule context.
+        cuda_toolchain: cuda_toolchain for which we configure features.
+        requested_features: List of features to be enabled.
+        unsupported_features: List of features that are unsupported by the current rule.
+    """
+    all_requested_features = _get_all_requested_features(ctx, cuda_toolchain, requested_features)
+    all_unsupported_features = _get_all_unsupported_features(ctx, cuda_toolchain, unsupported_features)
+    return config_helper.configure_features(
+        selectables_info = cuda_toolchain.selectables_info,
+        requested_features = all_requested_features,
+        unsupported_features = all_unsupported_features,
+        _debug = _debug,
+    )
+
+def _cuda_compile_commands(ctx, target, cc_toolchain):
+    for cuda_rule in _cuda_rules:
+        _check_srcs_extensions(ctx, ALLOW_CUDA_SRCS + ALLOW_CUDA_HDRS, cuda_rule)
+
+    cuda_toolchain = find_cuda_toolchain(ctx)
+    cuda_common = _create_common(ctx)
+    feature_configuration = _configure_features(
+        ctx = ctx,
+        cuda_toolchain = cuda_toolchain,
+        requested_features = ctx.features + [ACTION_NAMES.cuda_compile],
+        unsupported_features = ctx.disabled_features + DISABLED_FEATURES,
+    )
+
+    host_compiler = cc_toolchain.compiler_executable
+    cuda_compiler = cuda_toolchain.compiler_executable
+
+    _compile_flags = cuda_common.compile_flags
 
     srcs = _sources(ctx, target)
 
-    is_cuda_target = _is_cuda_target(srcs)
+    compile_commands = []
 
-    compiler_options = None
-    if is_cuda_target:
+    for src in srcs:
+        compiler_options = None
+        compile_flags = _compile_flags
         compile_variables = cuda_helper.create_compile_variables(
             feature_configuration = feature_configuration,
             cuda_toolchain = cuda_toolchain,
             compile_flags = cuda_common.compile_flags,
+            cuda_archs_info = cuda_common.cuda_archs_info,
+            host_compiler = host_compiler,
+            source_file = src.path,
+            output_file = "666",
         )
         compiler_options = cuda_helper.get_command_line(
             info = feature_configuration,
-            action = CUDA_COMPILE_ACTION_NAME,
+            action = ACTION_NAMES.cuda_compile,
             value = compile_variables,
         )
-        compile_flags.append("-x cu")  # Force language mode for header files.
+        compile_flags.extend(ctx.rule.attr.copts if "copts" in dir(ctx.rule.attr) else [])
 
-    compile_flags.extend(ctx.rule.attr.copts if "copts" in dir(ctx.rule.attr) else [])
+        cmdline_list = [cuda_compiler]
+        cmdline_list.extend(compiler_options)
+        cmdline_list.extend(compile_flags)
+        cmdline = " ".join(cmdline_list)
 
-    cmdline_list = [compiler]
-    cmdline_list.extend(compiler_options)
-    cmdline_list.extend(compile_flags)
-    cmdline = " ".join(cmdline_list)
-
-    compile_commands = []
-    for src in srcs:
         compile_commands.append(struct(
             cmdline = cmdline + " -c " + src.path,
             src = src,
         ))
     return compile_commands
+
+# def _cuda_compile_commands(ctx, target, feature_configuration, cuda_toolchain):
+#     cuda_common = cuda_helper.create_common(ctx)
+
+#     compiler = str(
+#         cuda_helper.get_tool_for_action(
+#             info = feature_configuration,
+#             action_name = ACTION_NAMES.cuda_compile,
+#         ),
+#     )
+#     compile_flags = cuda_common.compile_flags
+
+#     srcs = _sources(ctx, target)
+
+#     is_cuda_target = _is_cuda_target(srcs)
+
+#     compiler_options = None
+#     if is_cuda_target:
+#         compile_variables = cuda_helper.create_compile_variables(
+#             feature_configuration = feature_configuration,
+#             cuda_toolchain = cuda_toolchain,
+#             compile_flags = cuda_common.compile_flags,
+#         )
+#         compiler_options = cuda_helper.get_command_line(
+#             info = feature_configuration,
+#             action = ACTION_NAMES.cuda_compile,
+#             value = compile_variables,
+#         )
+#         compile_flags.append("-x cu")  # Force language mode for header files.
+
+#     compile_flags.extend(ctx.rule.attr.copts if "copts" in dir(ctx.rule.attr) else [])
+
+#     cmdline_list = [compiler]
+#     cmdline_list.extend(compiler_options)
+#     cmdline_list.extend(compile_flags)
+#     cmdline = " ".join(cmdline_list)
+
+#     compile_commands = []
+#     for src in srcs:
+#         compile_commands.append(struct(
+#             cmdline = cmdline + " -c " + src.path,
+#             src = src,
+#         ))
+#     return compile_commands
 
 def _compilation_database_aspect_impl(target, ctx):
     # Write the compile commands for this target to a file, and return
@@ -375,22 +657,14 @@ def _compilation_database_aspect_impl(target, ctx):
         unsupported_features = ctx.disabled_features + DISABLED_FEATURES,
     )
 
-    if cuda_enable and ctx.rule.kind in _cuda_rules:
-        cuda_toolchain = find_cuda_toolchain(ctx)
-        cuda_feature_configuration = cuda_helper.configure_features(
-            ctx = ctx,
-            cuda_toolchain = cuda_toolchain,
-            requested_features = ctx.features,
-            unsupported_features = ctx.disabled_features + DISABLED_FEATURES,
-        )
-        compile_commands = _cuda_compile_commands(ctx, target, cuda_feature_configuration, cuda_toolchain)
-
     if ctx.rule.kind in _cc_rules:
         compile_commands = _cc_compile_commands(ctx, target, cc_feature_configuration, cc_toolchain)
     elif ctx.rule.kind in _objc_rules:
         compile_commands = _objc_compile_commands(ctx, target, cc_feature_configuration, cc_toolchain)
+    elif cuda_enable and ctx.rule.kind in _cuda_rules:
+        compile_commands = _cuda_compile_commands(ctx = ctx, target = target, cc_toolchain = cc_toolchain)
     else:
-        fail("Unsupported rule: " + ctx.rule.kind)
+        fail("unsupported rule: " + ctx.rule.kind)
 
     srcs = []
     for compile_command in compile_commands:
@@ -410,9 +684,14 @@ def _compilation_database_aspect_impl(target, ctx):
     compilation_db = depset(compilation_db, transitive = transitive_compilation_db)
     all_compdb_files = depset([compdb_file], transitive = all_compdb_files)
     all_header_files.append(target[CcInfo].compilation_context.headers)
+    if cuda_enable:
+        cuda_common = _create_common(ctx)
+        all_header_files.append(cuda_common.headers)
 
     return [
-        CompilationAspect(compilation_db = compilation_db),
+        CompilationAspect(
+            compilation_db = compilation_db,
+        ),
         OutputGroupInfo(
             compdb_files = all_compdb_files,
             header_files = depset(transitive = all_header_files),
@@ -436,7 +715,7 @@ compilation_database_aspect = aspect(
     },
     fragments = ["cpp", "objc", "apple"],
     provides = [CompilationAspect],
-    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"] + [use_cuda_toolchain] if cuda_enable else [],
     implementation = _compilation_database_aspect_impl,
     apply_to_generating_rules = True,
 )

--- a/aspects.bzl
+++ b/aspects.bzl
@@ -30,10 +30,7 @@ load(
     "OBJCPP_COMPILE_ACTION_NAME",
     "OBJC_COMPILE_ACTION_NAME",
 )
-load("@rules_cuda//cuda/private:toolchain.bzl", "find_cuda_toolchain")
-load("@rules_cuda//cuda/private:action_names.bzl", CUDA_COMPILE_ACTION_NAME = "CUDA_COMPILE")
-load("@rules_cuda//cuda/private:cuda_helper.bzl", "cuda_helper")
-load("@com_grail_bazel_config_compdb//:config.bzl", "cuda_enable")
+load("@com_grail_bazel_config_compdb//:config.bzl", "CUDA_COMPILE_ACTION_NAME", "cuda_enable", "cuda_helper", "find_cuda_toolchain")
 
 CompilationAspect = provider()
 
@@ -378,7 +375,7 @@ def _compilation_database_aspect_impl(target, ctx):
         unsupported_features = ctx.disabled_features + DISABLED_FEATURES,
     )
 
-    if cuda_enable:
+    if cuda_enable and ctx.rule.kind in _cuda_rules:
         cuda_toolchain = find_cuda_toolchain(ctx)
         cuda_feature_configuration = cuda_helper.configure_features(
             ctx = ctx,
@@ -386,9 +383,7 @@ def _compilation_database_aspect_impl(target, ctx):
             requested_features = ctx.features,
             unsupported_features = ctx.disabled_features + DISABLED_FEATURES,
         )
-
-        if ctx.rule.kind in _cuda_rules:
-            compile_commands = _cuda_compile_commands(ctx, target, cuda_feature_configuration, cuda_toolchain)
+        compile_commands = _cuda_compile_commands(ctx, target, cuda_feature_configuration, cuda_toolchain)
 
     if ctx.rule.kind in _cc_rules:
         compile_commands = _cc_compile_commands(ctx, target, cc_feature_configuration, cc_toolchain)

--- a/aspects.bzl
+++ b/aspects.bzl
@@ -33,6 +33,7 @@ load(
 load("@rules_cuda//cuda/private:toolchain.bzl", "find_cuda_toolchain")
 load("@rules_cuda//cuda/private:action_names.bzl", CUDA_COMPILE_ACTION_NAME = "CUDA_COMPILE")
 load("@rules_cuda//cuda/private:cuda_helper.bzl", "cuda_helper")
+load("@com_grail_bazel_config_compdb//:config.bzl", "cuda_enable")
 
 CompilationAspect = provider()
 
@@ -389,7 +390,7 @@ def _compilation_database_aspect_impl(target, ctx):
         compile_commands = _cc_compile_commands(ctx, target, cc_feature_configuration, cc_toolchain)
     elif ctx.rule.kind in _objc_rules:
         compile_commands = _objc_compile_commands(ctx, target, cc_feature_configuration, cc_toolchain)
-    elif ctx.rule.kind in _cuda_rules:
+    elif cuda_enable and ctx.rule.kind in _cuda_rules:
         compile_commands = _cuda_compile_commands(ctx, target, cuda_feature_configuration, cuda_toolchain)
     else:
         fail("Unsupported rule: " + ctx.rule.kind)

--- a/config.bzl
+++ b/config.bzl
@@ -17,26 +17,45 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 _cuda_config = """
 load("@rules_cuda//cuda:deps.bzl", _register_detected_cuda_toolchains = "register_detected_cuda_toolchains", _rules_cuda_deps = "rules_cuda_deps")
-load("@rules_cuda//cuda/private:toolchain.bzl", _find_cuda_toolchain = "find_cuda_toolchain")
-load("@rules_cuda//cuda/private:action_names.bzl", "CUDA_COMPILE")
+load("@rules_cuda//cuda/private:toolchain.bzl", _find_cuda_toolchain = "find_cuda_toolchain", _use_cuda_toolchain = "use_cuda_toolchain")
+load("@rules_cuda//cuda/private:rules/common.bzl", _ALLOW_CUDA_HDRS = "ALLOW_CUDA_HDRS", _ALLOW_CUDA_SRCS = "ALLOW_CUDA_SRCS")
 load("@rules_cuda//cuda/private:cuda_helper.bzl", _cuda_helper = "cuda_helper")
+load("@bazel_skylib//lib:paths.bzl", _paths = "paths")
+load("@bazel_skylib//rules:common_settings.bzl", _BuildSettingInfo = "BuildSettingInfo")
+load("@rules_cuda//cuda/private:providers.bzl", _CudaArchsInfo = "CudaArchsInfo", _CudaInfo = "CudaInfo")
+load("@rules_cuda//cuda/private:action_names.bzl", _ACTION_NAMES = "ACTION_NAMES")
+load("@rules_cuda//cuda/private:toolchain_config_lib.bzl", _config_helper = "config_helper", _unique = "unique")
 register_detected_cuda_toolchains = _register_detected_cuda_toolchains
 rules_cuda_deps = _rules_cuda_deps
 find_cuda_toolchain = _find_cuda_toolchain
-CUDA_COMPILE_ACTION_NAME = CUDA_COMPILE
+use_cuda_toolchain = "@rules_cuda" + ''.join(_use_cuda_toolchain())
+ALLOW_CUDA_HDRS = _ALLOW_CUDA_HDRS
+ALLOW_CUDA_SRCS = _ALLOW_CUDA_SRCS
 cuda_helper = _cuda_helper
+paths = _paths
+BuildSettingInfo = _BuildSettingInfo
+CudaArchsInfo = _CudaArchsInfo
+CudaInfo = _CudaInfo
+ACTION_NAMES = _ACTION_NAMES
+unique = _unique
+config_helper = _config_helper
 """
 
 _empty_config = """
-def rules_cuda_deps():
-    return
-def register_detected_cuda_toolchains():
-    return
-def find_cuda_toolchain():
-    return
-CUDA_COMPILE_ACTION_NAME=""
-def cuda_helper():
-    return
+register_detected_cuda_toolchains = ""
+rules_cuda_deps = ""
+find_cuda_toolchain = ""
+use_cuda_toolchain = ""
+ALLOW_CUDA_HDRS = ""
+ALLOW_CUDA_SRCS = ""
+cuda_helper = ""
+paths = ""
+BuildSettingInfo = ""
+CudaArchsInfo = ""
+CudaInfo = ""
+ACTION_NAMES = "”
+unique = ""
+config_helper = ""
 """
 
 def _config_compdb_repository_impl(rctx):

--- a/config.bzl
+++ b/config.bzl
@@ -1,0 +1,56 @@
+# Copyright 2022 Aqrose Technology, Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def _config_compdb_repository_impl(rctx):
+    if rctx.attr.cuda_enable:
+        maybe(
+            name = rules_cuda,
+            repo_rule = http_archive,
+            sha256 = "99914664a13dd441837fba8fceb07a125a945e4a750facbbfe85a8ec1fbd9c3c",
+            urls = ["https://github.com/cloudhan/rules_cuda/archive/6f05e4d11b06ee542509e5ec65554118063351bf.tar.gz"],
+        )
+
+        load("@rules_cuda//cuda:deps.bzl", "register_detected_cuda_toolchains", "rules_cuda_deps")
+
+        rules_cuda_deps()
+        register_detected_cuda_toolchains()
+
+    rctx.file("BUILD.bazel", "")
+    rctx.file("config.bzl", "global_filter_flags = %s" % rctx.attr.global_filter_flags)
+    rctx.file("config.bzl", "cuda_enable = %s" % rctx.attr.cuda_enable)
+
+    return
+
+config_compdb_repository = repository_rule(
+    implementation = _config_compdb_repository_impl,
+    local = True,
+    attrs = {
+        "global_filter_flags": attr.string_list(
+            default = [
+                "-isysroot __BAZEL_XCODE_SDKROOT__",
+            ],
+            doc = "Filter the flags in the compilation command that clang does not support.",
+        ),
+        "cuda_enable": attr.bool(
+            default = False,
+            doc = "Enable the cuda compiler.",
+        ),
+    },
+    doc = "To config compdb.",
+)
+
+def config_compdb(**kwargs):
+    config_compdb_repository(name = "com_grail_bazel_config_compdb", **kwargs)

--- a/config.bzl
+++ b/config.bzl
@@ -12,23 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@rules_cuda//cuda:deps.bzl", "register_detected_cuda_toolchains", "rules_cuda_deps")
 
 def _config_compdb_repository_impl(rctx):
     if rctx.attr.cuda_enable:
-        maybe(
-            name = "rules_cuda",
-            repo_rule = http_archive,
-            sha256 = "99914664a13dd441837fba8fceb07a125a945e4a750facbbfe85a8ec1fbd9c3c",
-            urls = ["https://github.com/cloudhan/rules_cuda/archive/6f05e4d11b06ee542509e5ec65554118063351bf.tar.gz"],
-        )
+        rules_cuda_deps()
+        register_detected_cuda_toolchains()
 
     rctx.file("BUILD.bazel", "")
     rctx.file("config.bzl", "global_filter_flags = %s" % rctx.attr.global_filter_flags)
     rctx.file("config.bzl", "cuda_enable = %s" % rctx.attr.cuda_enable)
-
-    return
 
 config_compdb_repository = repository_rule(
     implementation = _config_compdb_repository_impl,

--- a/config.bzl
+++ b/config.bzl
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 def _config_compdb_repository_impl(rctx):

--- a/config.bzl
+++ b/config.bzl
@@ -15,13 +15,8 @@
 load("@rules_cuda//cuda:deps.bzl", "register_detected_cuda_toolchains", "rules_cuda_deps")
 
 def _config_compdb_repository_impl(rctx):
-    if rctx.attr.cuda_enable:
-        rules_cuda_deps()
-        register_detected_cuda_toolchains()
-
     rctx.file("BUILD.bazel", "")
-    rctx.file("config.bzl", "global_filter_flags = %s" % rctx.attr.global_filter_flags)
-    rctx.file("config.bzl", "cuda_enable = %s" % rctx.attr.cuda_enable)
+    rctx.file("config.bzl", "global_filter_flags = %s\ncuda_enable = %s\n" % (rctx.attr.global_filter_flags, rctx.attr.cuda_enable))
 
 config_compdb_repository = repository_rule(
     implementation = _config_compdb_repository_impl,
@@ -42,4 +37,8 @@ config_compdb_repository = repository_rule(
 )
 
 def config_compdb(**kwargs):
-    config_compdb_repository(name = "com_grail_bazel_config_compdb", **kwargs)
+    cuda_enable = kwargs.pop("cuda_enable", False)
+    if cuda_enable:
+        rules_cuda_deps()
+        register_detected_cuda_toolchains()
+    config_compdb_repository(name = "com_grail_bazel_config_compdb", cuda_enable = cuda_enable, **kwargs)

--- a/config.bzl
+++ b/config.bzl
@@ -18,16 +18,11 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 def _config_compdb_repository_impl(rctx):
     if rctx.attr.cuda_enable:
         maybe(
-            name = rules_cuda,
+            name = "rules_cuda",
             repo_rule = http_archive,
             sha256 = "99914664a13dd441837fba8fceb07a125a945e4a750facbbfe85a8ec1fbd9c3c",
             urls = ["https://github.com/cloudhan/rules_cuda/archive/6f05e4d11b06ee542509e5ec65554118063351bf.tar.gz"],
         )
-
-        load("@rules_cuda//cuda:deps.bzl", "register_detected_cuda_toolchains", "rules_cuda_deps")
-
-        rules_cuda_deps()
-        register_detected_cuda_toolchains()
 
     rctx.file("BUILD.bazel", "")
     rctx.file("config.bzl", "global_filter_flags = %s" % rctx.attr.global_filter_flags)

--- a/defs.bzl
+++ b/defs.bzl
@@ -20,7 +20,7 @@ def _compilation_database_impl(ctx):
 
     if ctx.attr.disable:
         ctx.actions.write(output = ctx.outputs.filename, content = "[]\n")
-        return
+        return []
 
     compilation_db = []
     all_headers = []
@@ -36,6 +36,11 @@ def _compilation_database_impl(ctx):
     content = json.encode(compilation_db.to_list())
     content = content.replace("__EXEC_ROOT__", exec_root)
     content = content.replace("-isysroot __BAZEL_XCODE_SDKROOT__", "")
+    # Format json
+    content = ",\n".join(content.split(","))
+    content = content.replace("[", "[\n")
+    content = content.replace("]", "\n]\n")
+
     ctx.actions.write(output = ctx.outputs.filename, content = content)
 
     return [

--- a/defs.bzl
+++ b/defs.bzl
@@ -49,7 +49,7 @@ def _compilation_database_impl(ctx):
     content = content.replace("/std:", "-std=")
 
     # Format json.
-    content = ",\n".join(content.split(","))
+    content = "},\n".join(content.split("},"))
     content = content.replace("[", "[\n")
     content = content.replace("]", "\n]\n")
 

--- a/defs.bzl
+++ b/defs.bzl
@@ -45,7 +45,7 @@ def _compilation_database_impl(ctx):
         content = content.replace(flag, "")
 
     # Replace msvc compilation command to clang.
-    content.replace("/std:", "-std=")
+    content = content.replace("/std:", "-std=")
 
     # Format json.
     content = ",\n".join(content.split(","))

--- a/defs.bzl
+++ b/defs.bzl
@@ -34,6 +34,7 @@ def _compilation_database_impl(ctx):
 
     exec_root = ctx.attr.output_base + "/execroot/" + ctx.workspace_name
 
+    # to_list() will return a list of the elements, without duplicates.
     content = json.encode(compilation_db.to_list())
     content = content.replace("__EXEC_ROOT__", exec_root)
 

--- a/defs.bzl
+++ b/defs.bzl
@@ -37,15 +37,15 @@ def _compilation_database_impl(ctx):
     content = json.encode(compilation_db.to_list())
     content = content.replace("__EXEC_ROOT__", exec_root)
 
-    filter_flags = ctx.attr.filter_flags
+    filter_flags = []
     filter_flags.extend(global_filter_flags)
+    filter_flags.extend(ctx.attr.filter_flags)
 
     for flag in filter_flags:
         content = content.replace(flag, "")
 
-    # For windows, replace msvc compilation command to clang.
-    if ctx.os.name.lower().startswith("windows") == True:
-        content.replace("/std:", "-std=")
+    # Replace msvc compilation command to clang.
+    content.replace("/std:", "-std=")
 
     # Format json.
     content = ",\n".join(content.split(","))

--- a/defs.bzl
+++ b/defs.bzl
@@ -36,6 +36,9 @@ def _compilation_database_impl(ctx):
     content = json.encode(compilation_db.to_list())
     content = content.replace("__EXEC_ROOT__", exec_root)
     content = content.replace("-isysroot __BAZEL_XCODE_SDKROOT__", "")
+    for flag in ctx.attr.filter_flags:
+        content = content.replace(flag, "")
+
     # Format json
     content = ",\n".join(content.split(","))
     content = content.replace("[", "[\n")
@@ -69,6 +72,12 @@ _compilation_database = rule(
         ),
         "filename": attr.output(
             doc = "Name of the generated compilation database.",
+        ),
+        "filter_flags": attr.string_list(
+            default = [
+                "-fno-canonical-system-headers",
+            ],
+            doc = "Filter the flags in the compilation command that clang does not support.",
         ),
     },
     implementation = _compilation_database_impl,

--- a/deps.bzl
+++ b/deps.bzl
@@ -16,15 +16,3 @@ load("@com_grail_bazel_compdb//:tools.bzl", "setup_tools")
 
 def bazel_compdb_deps():
     setup_tools()
-
-    maybe(
-        name = rules_cuda,
-        repo_rule = http_archive,
-        sha256 = "99914664a13dd441837fba8fceb07a125a945e4a750facbbfe85a8ec1fbd9c3c",
-        urls = ["https://github.com/cloudhan/rules_cuda/archive/6f05e4d11b06ee542509e5ec65554118063351bf.tar.gz"],
-    )
-
-    load("@rules_cuda//cuda:deps.bzl", "register_detected_cuda_toolchains", "rules_cuda_deps")
-
-    rules_cuda_deps()
-    register_detected_cuda_toolchains()

--- a/deps.bzl
+++ b/deps.bzl
@@ -16,3 +16,15 @@ load("@com_grail_bazel_compdb//:tools.bzl", "setup_tools")
 
 def bazel_compdb_deps():
     setup_tools()
+
+    maybe(
+        name = rules_cuda,
+        repo_rule = http_archive,
+        sha256 = "99914664a13dd441837fba8fceb07a125a945e4a750facbbfe85a8ec1fbd9c3c",
+        urls = ["https://github.com/cloudhan/rules_cuda/archive/6f05e4d11b06ee542509e5ec65554118063351bf.tar.gz"],
+    )
+
+    load("@rules_cuda//cuda:deps.bzl", "register_detected_cuda_toolchains", "rules_cuda_deps")
+
+    rules_cuda_deps()
+    register_detected_cuda_toolchains()

--- a/deps.bzl
+++ b/deps.bzl
@@ -13,15 +13,24 @@
 # limitations under the License.
 
 load("@com_grail_bazel_compdb//:tools.bzl", "setup_tools")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 def bazel_compdb_deps():
     setup_tools()
 
     maybe(
+        name = "bazel_skylib",
+        repo_rule = http_archive,
+        sha256 = "d847b08d6702d2779e9eb399b54ff8920fa7521dc45e3e53572d1d8907767de7",
+        strip_prefix = "bazel-skylib-2a87d4a62af886fb320883aba102255aba87275e",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2a87d4a62af886fb320883aba102255aba87275e.tar.gz"],
+    )
+
+    maybe(
         name = "rules_cuda",
         repo_rule = http_archive,
-        sha256 = "99914664a13dd441837fba8fceb07a125a945e4a750facbbfe85a8ec1fbd9c3c",
-        urls = ["https://github.com/cloudhan/rules_cuda/archive/6f05e4d11b06ee542509e5ec65554118063351bf.tar.gz"],
+        sha256 = "a10a7efbf886a42f5c849dd515c22b72a58d37fdd8ee1436327c47f525e70f26",
+        strip_prefix = "rules_cuda-19f91525682511a2825037e3ac568cba22329733",
+        urls = ["https://github.com/cloudhan/rules_cuda/archive/19f91525682511a2825037e3ac568cba22329733.zip"],
     )

--- a/deps.bzl
+++ b/deps.bzl
@@ -13,6 +13,15 @@
 # limitations under the License.
 
 load("@com_grail_bazel_compdb//:tools.bzl", "setup_tools")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def bazel_compdb_deps():
     setup_tools()
+
+    maybe(
+        name = "rules_cuda",
+        repo_rule = http_archive,
+        sha256 = "99914664a13dd441837fba8fceb07a125a945e4a750facbbfe85a8ec1fbd9c3c",
+        urls = ["https://github.com/cloudhan/rules_cuda/archive/6f05e4d11b06ee542509e5ec65554118063351bf.tar.gz"],
+    )

--- a/deps.bzl
+++ b/deps.bzl
@@ -13,24 +13,11 @@
 # limitations under the License.
 
 load("@com_grail_bazel_compdb//:tools.bzl", "setup_tools")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@com_grail_bazel_config_compdb//:config.bzl", "cuda_enable", "register_detected_cuda_toolchains", "rules_cuda_deps")
 
 def bazel_compdb_deps():
     setup_tools()
 
-    maybe(
-        name = "bazel_skylib",
-        repo_rule = http_archive,
-        sha256 = "d847b08d6702d2779e9eb399b54ff8920fa7521dc45e3e53572d1d8907767de7",
-        strip_prefix = "bazel-skylib-2a87d4a62af886fb320883aba102255aba87275e",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2a87d4a62af886fb320883aba102255aba87275e.tar.gz"],
-    )
-
-    maybe(
-        name = "rules_cuda",
-        repo_rule = http_archive,
-        sha256 = "a10a7efbf886a42f5c849dd515c22b72a58d37fdd8ee1436327c47f525e70f26",
-        strip_prefix = "rules_cuda-19f91525682511a2825037e3ac568cba22329733",
-        urls = ["https://github.com/cloudhan/rules_cuda/archive/19f91525682511a2825037e3ac568cba22329733.zip"],
-    )
+    if cuda_enable:
+        rules_cuda_deps()
+        register_detected_cuda_toolchains()

--- a/tests/.bazelrc
+++ b/tests/.bazelrc
@@ -7,8 +7,10 @@ build --flag_alias=cuda_compiler=@rules_cuda//cuda:compiler
 build --flag_alias=cuda_archs=@rules_cuda//cuda:archs
 build --flag_alias=cuda_copts=@rules_cuda//cuda:copts
 
-build --enable_cuda=True
-build --cuda_compiler=nvcc
-build --cuda_archs=sm_60;sm_75;sm_86
+build:cuda --enable_cuda=True
+build:cuda --cuda_compiler=nvcc
+build:cuda --cuda_archs=sm_60;sm_75;sm_86
 
-build:windows --cuda_copts=-std=c++17,-extended-lambda,-Xcudafe="--diag_suppress=unsigned_compare_with_zero",-Xcompiler=/std:c++17,-Xcompiler=/utf-8,-Xcompiler=/Zc:preprocessor
+build:cuda --cuda_copts=-std=c++17,-extended-lambda,-Xcudafe="--diag_suppress=unsigned_compare_with_zero",-Xcompiler=/std:c++17,-Xcompiler=/utf-8,-Xcompiler=/Zc:preprocessor
+
+<!-- build --config=cuda -->

--- a/tests/.bazelrc
+++ b/tests/.bazelrc
@@ -13,4 +13,4 @@ build:cuda --cuda_archs=sm_60;sm_75;sm_86
 
 build:cuda --cuda_copts=-std=c++17,-extended-lambda,-Xcudafe="--diag_suppress=unsigned_compare_with_zero",-Xcompiler=/std:c++17,-Xcompiler=/utf-8,-Xcompiler=/Zc:preprocessor
 
-<!-- build --config=cuda -->
+build --config=cuda

--- a/tests/.bazelrc
+++ b/tests/.bazelrc
@@ -1,0 +1,14 @@
+build --enable_platform_specific_config
+
+build:windows --copt=/std:c++17
+
+build --flag_alias=enable_cuda=@rules_cuda//cuda:enable
+build --flag_alias=cuda_compiler=@rules_cuda//cuda:compiler
+build --flag_alias=cuda_archs=@rules_cuda//cuda:archs
+build --flag_alias=cuda_copts=@rules_cuda//cuda:copts
+
+build --enable_cuda=True
+build --cuda_compiler=nvcc
+build --cuda_archs=sm_60;sm_75;sm_86
+
+build:windows --cuda_copts=-std=c++17,-extended-lambda,-Xcudafe="--diag_suppress=unsigned_compare_with_zero",-Xcompiler=/std:c++17,-Xcompiler=/utf-8,-Xcompiler=/Zc:preprocessor

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -12,7 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@rules_cuda//cuda:defs.bzl", "cuda_library")
+load("@com_grail_bazel_compdb//:defs.bzl", "compilation_database")
+load("@com_grail_bazel_output_base_util//:defs.bzl", "OUTPUT_BASE")
+
+cuda_library(
+    name = "d",
+    srcs = ["d.cu"],
+    hdrs = ["d.hpp"],
+)
+
+cc_binary(
+    name = "test",
+    srcs = ["test.cpp"],
+    deps = [":d"],
+)
+
+compilation_database(
+    name = "compdb_cuda",
+    filename = "test.json",
+    output_base = OUTPUT_BASE,
+    targets = [":d"],
+)
 
 cc_library(
     name = "a",
@@ -42,9 +63,6 @@ filegroup(
     name = "b_filegrp",
     srcs = ["b"],
 )
-
-load("@com_grail_bazel_compdb//:defs.bzl", "compilation_database")
-load("@com_grail_bazel_output_base_util//:defs.bzl", "OUTPUT_BASE")
 
 compilation_database(
     name = "compdb",

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -22,3 +22,7 @@ local_repository(
 load("@com_grail_bazel_compdb//:deps.bzl", "bazel_compdb_deps")
 
 bazel_compdb_deps()
+
+load("@com_grail_bazel_compdb//:config.bzl", "config_compdb")
+
+config_compdb()

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -24,6 +24,7 @@ local_repository(
 load("@com_grail_bazel_compdb//:config.bzl", "config_compdb")
 
 config_compdb(
+    cuda_enable = True,
 )
 
 load("@com_grail_bazel_compdb//:deps.bzl", "bazel_compdb_deps")

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -19,10 +19,11 @@ local_repository(
     path = "..",
 )
 
+load("@com_grail_bazel_compdb//:config.bzl", "config_compdb")
+
+config_compdb(
+)
+
 load("@com_grail_bazel_compdb//:deps.bzl", "bazel_compdb_deps")
 
 bazel_compdb_deps()
-
-load("@com_grail_bazel_compdb//:config.bzl", "config_compdb")
-
-config_compdb()

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -14,6 +14,8 @@
 
 workspace(name = "com_grail_bazel_compdb_tests")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 local_repository(
     name = "com_grail_bazel_compdb",
     path = "..",
@@ -22,9 +24,21 @@ local_repository(
 load("@com_grail_bazel_compdb//:config.bzl", "config_compdb")
 
 config_compdb(
-    cuda_enable = True,
 )
 
 load("@com_grail_bazel_compdb//:deps.bzl", "bazel_compdb_deps")
 
 bazel_compdb_deps()
+
+http_archive(
+    name = "rules_cuda",
+    sha256 = "a10a7efbf886a42f5c849dd515c22b72a58d37fdd8ee1436327c47f525e70f26",
+    strip_prefix = "rules_cuda-19f91525682511a2825037e3ac568cba22329733",
+    urls = ["https://github.com/cloudhan/rules_cuda/archive/19f91525682511a2825037e3ac568cba22329733.zip"],
+)
+
+load("@rules_cuda//cuda:deps.bzl", "register_detected_cuda_toolchains", "rules_cuda_deps")
+
+rules_cuda_deps()
+
+register_detected_cuda_toolchains()

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -22,6 +22,7 @@ local_repository(
 load("@com_grail_bazel_compdb//:config.bzl", "config_compdb")
 
 config_compdb(
+    cuda_enable = True,
 )
 
 load("@com_grail_bazel_compdb//:deps.bzl", "bazel_compdb_deps")

--- a/tests/d.cu
+++ b/tests/d.cu
@@ -1,0 +1,11 @@
+#include "d.hpp"
+#include <cstdio>
+
+__global__ void kernel() {
+  printf("kernel id = %d\n", blockIdx.x * blockDim.x + threadIdx.x);
+}
+
+int launch() {
+  kernel<<<2, 3>>>();
+  return 0;
+}

--- a/tests/d.hpp
+++ b/tests/d.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+int launch();

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1,0 +1,8 @@
+#include "d.hpp"
+#include <stdlib.h>
+
+int main() {
+  launch();
+  system("pause");
+  return 0;
+}

--- a/tools.bzl
+++ b/tools.bzl
@@ -13,16 +13,16 @@
 # limitations under the License.
 
 def _bazel_output_base_util_impl(rctx):
-    if rctx.os.name.lower().startswith("windows") == True:
+    if rctx.os.name.lower().startswith("windows"):
         res = rctx.execute(["cmd", "/c", "echo", "%cd%"])
     else:
         res = rctx.execute(["pwd"])
 
     if res.return_code != 0:
-        fail("Getting output base failed (%d): %s" % (res.return_code, res.stderr))
+        fail("getting output base failed (%d): %s" % (res.return_code, res.stderr))
 
     # Strip last two path components.
-    if rctx.os.name.lower().startswith("windows") == True:
+    if rctx.os.name.lower().startswith("windows"):
         path_components = res.stdout.rstrip("\n").split("\\")[:-2]
     else:
         path_components = res.stdout.rstrip("\n").split("/")[:-2]

--- a/tools.bzl
+++ b/tools.bzl
@@ -13,12 +13,22 @@
 # limitations under the License.
 
 def _bazel_output_base_util_impl(rctx):
-    res = rctx.execute(["pwd"])
+    if rctx.os.name.lower().startswith("windows") == True:
+        res = rctx.execute(["cmd", "/c", "echo", "%cd%"])
+    elif rctx.os.name.startswith("linux") == True:
+        res = rctx.execute(["pwd"])
+    else:
+        fail("Unknown operating system combo: os = {}".format(rctx.os.name))
+
     if res.return_code != 0:
-        fail("getting output base failed (%d): %s" % (res.return_code, res.stderr))
+        fail("Getting output base failed (%d): %s" % (res.return_code, res.stderr))
 
     # Strip last two path components.
-    path_components = res.stdout.rstrip("\n").split("/")[:-2]
+    if rctx.os.name.lower().startswith("windows") == True:
+        path_components = res.stdout.rstrip("\n").split("\\")[:-2]
+    else:
+        path_components = res.stdout.rstrip("\n").split("/")[:-2]
+
     output_base = "/".join(path_components)
 
     rctx.file("BUILD.bazel", "")


### PR DESCRIPTION
- Support to get `OUTPUT_BASE` for windows.
- Format `compile_commands.json`.
- Add `filter_flags` to filter the flags in the compilation command that clang does not support.